### PR TITLE
View and Code toggle in border-less-cards

### DIFF
--- a/pages/components/cards.tsx
+++ b/pages/components/cards.tsx
@@ -41,8 +41,8 @@ function CardsComponents() {
           <div className="border">
             <ComponentLayout
               title="Border Less Cards"
-              view={<BorderLessCardsCode />}
-              doc={<BorderLessCardsView />}
+              view={<BorderLessCardsView />}
+              doc={<BorderLessCardsCode />}
               code="border-less-cards-code"
               preview="border-less-cards-preview"
             />


### PR DESCRIPTION
In the borderless cards, components on clicking code view was opening and vice versa. Fixed the issue.